### PR TITLE
Automation and replacing graphviz with d2

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,3 +349,4 @@ list of public tech migrations (create a PR to if you have correction or additio
 *   [Chartmetric](https://www.youtube.com/watch?v=DdTCFrMhbTE) (2025) from AuroraRDS+Slowflake+ElasticSearch+Airflow to Clickhouse
 *   [FinBox](https://www.youtube.com/watch?v=PghysB5KYXU) (2025) from Airflow+DataBricks+SnowFlake+RedShift to Debezium+Kafka+VectorDev+ClickHouse
 *   [GitLab](https://clickhouse.com/blog/how-gitlab-uses-clickhouse-to-scale-analytical-workloads?rdt_cid=5217830554598346520&utm_campaign=reddit-awareness&utm_medium=paid-social&utm_source=reddit) (2025) from PostgreSQL to Clickhouse
+


### PR DESCRIPTION
Still testing.

I've attempted to add some automation.

Upon editing readme.md, it attempts to update the graph using d2 rather than graphviz.
Upon updating the png it creates a release, allowing those people who are watching for releases:

<img width="590" height="434" alt="image" src="https://github.com/user-attachments/assets/16a4f72b-616a-4aac-9f01-8e9cf684d499" />

Get notifications.